### PR TITLE
Attempt to implement changes necessary for JIT on Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,32 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MASTER_PROJECT ON)
 endif()
 
+# Add the module directory to the list of paths
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
+
+# Arch detection
+include(DetectArchitecture)
+if (MSVC)
+    detect_architecture("_M_AMD64" x86_64)
+    detect_architecture("_M_ARM64" Aarch64)
+else()
+    detect_architecture("__x86_64__" x86_64)
+    detect_architecture("__aarch64__" Aarch64)
+endif()
+if (NOT DEFINED DYNARMIC_ARCHITECTURE)
+    message(FATAL_ERROR "Unsupported architecture encountered. Ending CMake generation.")
+endif()
+message(STATUS "Target architecture: ${DYNARMIC_ARCHITECTURE}")
+
+set(REQUIRES_NO_EXECUTE_SUPPORT OFF)
+#Apple Silicon chips require W^X
+if(APPLE AND ARCHITECTURE_Aarch64)
+    set(REQUIRES_NO_EXECUTE_SUPPORT ON)
+endif()
+
 # Dynarmic project options
 option(DYNARMIC_ENABLE_CPU_FEATURE_DETECTION "Turning this off causes dynarmic to assume the host CPU doesn't support anything later than SSE3" ON)
-option(DYNARMIC_ENABLE_NO_EXECUTE_SUPPORT "Enables support for systems that require W^X" OFF)
+option(DYNARMIC_ENABLE_NO_EXECUTE_SUPPORT "Enables support for systems that require W^X" ${REQUIRES_NO_EXECUTE_SUPPORT})
 option(DYNARMIC_FATAL_ERRORS "Errors are fatal" OFF)
 option(DYNARMIC_TESTS "Build tests" ${MASTER_PROJECT})
 option(DYNARMIC_TESTS_USE_UNICORN "Enable fuzzing tests against unicorn" OFF)
@@ -37,9 +60,6 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(SEND_ERROR "In-source builds are not allowed.")
 endif()
-
-# Add the module directory to the list of paths
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 
 # Compiler flags
 if (MSVC)
@@ -98,20 +118,6 @@ else()
              -Wfatal-errors)
     endif()
 endif()
-
-# Arch detection
-include(DetectArchitecture)
-if (MSVC)
-    detect_architecture("_M_AMD64" x86_64)
-    detect_architecture("_M_ARM64" Aarch64)
-else()
-    detect_architecture("__x86_64__" x86_64)
-    detect_architecture("__aarch64__" Aarch64)
-endif()
-if (NOT DEFINED DYNARMIC_ARCHITECTURE)
-    message(FATAL_ERROR "Unsupported architecture encountered. Ending CMake generation.")
-endif()
-message(STATUS "Target architecture: ${DYNARMIC_ARCHITECTURE}")
 
 # Include Boost
 if (NOT TARGET boost)

--- a/src/backend/A64/block_of_code.cpp
+++ b/src/backend/A64/block_of_code.cpp
@@ -20,6 +20,10 @@
     #include <sys/mman.h>
 #endif
 
+#ifdef __APPLE__
+#include <pthread.h>
+#endif
+
 namespace Dynarmic::BackendA64 {
 
 const Arm64Gen::ARM64Reg BlockOfCode::ABI_RETURN  = Arm64Gen::ARM64Reg::X0;
@@ -86,11 +90,17 @@ void BlockOfCode::EnableWriting() {
 #ifdef DYNARMIC_ENABLE_NO_EXECUTE_SUPPORT
     ProtectMemory(GetCodePtr(), TOTAL_CODE_SIZE, false);
 #endif
+#ifdef __APPLE__
+    pthread_jit_write_protect_np(false);
+#endif
 }
 
 void BlockOfCode::DisableWriting() {
 #ifdef DYNARMIC_ENABLE_NO_EXECUTE_SUPPORT
     ProtectMemory(GetCodePtr(), TOTAL_CODE_SIZE, true);
+#endif
+#ifdef __APPLE__
+    pthread_jit_write_protect_np(true);
 #endif
 }
 

--- a/src/backend/A64/emitter/a64_emitter.cpp
+++ b/src/backend/A64/emitter/a64_emitter.cpp
@@ -366,12 +366,10 @@ void ARM64XEmitter::FlushIcacheSection(const u8* start, const u8* end) {
     if (start == end)
         return;
 
-#if defined(IOS)
+#if defined(__APPLE__)
     // Header file says this is equivalent to: sys_icache_invalidate(start, end -
     // start);
-    sys_cache_control(kCacheFunctionPrepareForExecution, start, end - start);
-#elif defined(__APPLE__)
-    sys_icache_invalidate(const_cast<u8*>(start), end - start);
+    sys_cache_control(kCacheFunctionPrepareForExecution, const_cast<u8*>(start), end - start);
 #else
     // Don't rely on GCC's __clear_cache implementation, as it caches
     // icache/dcache cache line sizes, that can vary between cores on

--- a/src/backend/A64/emitter/a64_emitter.cpp
+++ b/src/backend/A64/emitter/a64_emitter.cpp
@@ -8,6 +8,10 @@
 #include <cstring>
 #include <vector>
 
+#if defined(__APPLE__)
+#include <libkern/OSCacheControl.h>
+#endif
+
 #include "a64_emitter.h"
 #include "common/assert.h"
 #include "common/bit_util.h"
@@ -366,6 +370,8 @@ void ARM64XEmitter::FlushIcacheSection(const u8* start, const u8* end) {
     // Header file says this is equivalent to: sys_icache_invalidate(start, end -
     // start);
     sys_cache_control(kCacheFunctionPrepareForExecution, start, end - start);
+#elif defined(__APPLE__)
+    sys_icache_invalidate(const_cast<u8*>(start), end - start);
 #else
     // Don't rely on GCC's __clear_cache implementation, as it caches
     // icache/dcache cache line sizes, that can vary between cores on

--- a/src/backend/A64/emitter/code_block.h
+++ b/src/backend/A64/emitter/code_block.h
@@ -57,7 +57,11 @@ public:
 #if defined(_WIN32)
         void* ptr = VirtualAlloc(nullptr, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
+#if defined(__APPLE__)
+        void* ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE | MAP_JIT, -1, 0);
+#else
         void* ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0);
+#endif
 
         if (ptr == MAP_FAILED)
             ptr = nullptr;


### PR DESCRIPTION
as described on https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon

A follow up to #1, as that PR only addressed compilation errors.
Currently citra will crash when CPU JIT is enabled, and the crash log seems to indicate it's an assert.
Apparently the assert message doesn't get printed to the log, but I assume it's related to memory allocation or access.

This still needs to be tested on actual Apple Silicon.
Eventually more changes may be needed if Apple's guidance for JITs change, and also when linux on apple silicon matures, but this should be fine for now.