### PR TITLE
Fix A32-on-A64 for Apple Silicon

### DIFF
--- a/src/backend/A64/a32_emit_a64.cpp
+++ b/src/backend/A64/a32_emit_a64.cpp
@@ -1584,6 +1584,9 @@ void A32EmitA64::EmitPatchMovX0(CodePtr target_code_ptr) {
 void A32EmitA64::Unpatch(const IR::LocationDescriptor& location) {
     EmitA64::Unpatch(location);
     if (config.enable_fast_dispatch) {
+        code.DisableWriting();
+        SCOPE_EXIT { code.EnableWriting(); };
+
         (*fast_dispatch_table_lookup)(location.Value()) = {};
     }
 }


### PR DESCRIPTION
Unpatch is called from InvalidateBasicBlocks, which has temporarily enabled writing, and thus disabled execution. However, the fast dispatch lookup code is dynamically generated just like the rest of the JITed output and so also is currently not executable. Thus we must temporarily disable writing, and thus re-enable execution, whilst we run the lookup function, otherwise we will fault on jumping to it.